### PR TITLE
Uses Enumerator to loop over elements instead of IEnumerable

### DIFF
--- a/src/Dumpify.Tests/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DictionaryTypeRendererTests.cs
+++ b/src/Dumpify.Tests/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DictionaryTypeRendererTests.cs
@@ -1,0 +1,117 @@
+﻿using Newtonsoft.Json.Linq;
+using Spectre.Console.Rendering;
+using System.Collections;
+using System.Text.Json.Nodes;
+
+namespace Dumpify.Tests.Renderers.Spectre.Console.TableRenderer.CustomTypeRenderers;
+
+[TestClass]
+public class DictionaryTypeRendererTests
+{
+    [TestMethod]
+    [DynamicData(nameof(GetDataFor_DictionaryTypeRenderer_ShouldHandleInput_WhenInputHasIsIenumerableWithGenericKeyValuePair), DynamicDataSourceType.Method)]
+    public void DictionaryTypeRenderer_ShouldHandleInput_WhenInputHasIsIenumerableWithGenericKeyValuePair(object input, bool expectedItem1, List<(object?, object?)> expectedItem2)
+    {
+        //Arrange
+        IRendererHandler<IRenderable, SpectreRendererState> handler = default!;
+        var renderer = new DictionaryTypeRenderer(handler);
+        var generator = new MultiValueGenerator();
+        var descriptor = generator.Generate(input.GetType(), null, default!)!;
+
+        //Act
+        var result = renderer.ShouldHandle(descriptor, input);
+
+        //Assert
+        Assert.AreEqual(expectedItem1, result.Item1);
+        CollectionAssert.AreEquivalent(expectedItem2, (ICollection)result.Item2!);
+    }
+
+    private static IEnumerable<object[]> GetDataFor_DictionaryTypeRenderer_ShouldHandleInput_WhenInputHasIsIenumerableWithGenericKeyValuePair()
+    {
+        var resultList = new List<(object, object)>()
+        {
+            new ("key1", "value1"),
+            new ("key2", "value2"),
+        };
+        const string jsonstring
+        = """
+        {
+            "key1": "value1",
+            "key2": "value2"
+        }
+        """;
+        JsonObject systemTextJsonObject = JsonNode.Parse(jsonstring)!.AsObject();
+        JObject newtonsoftJsonObject = JObject.Parse(jsonstring);
+        yield return new object[]
+        {
+            new Dictionary<string, string>()
+            {
+                {"key1", "value1"},
+                {"key2", "value2"},
+            },
+            true,
+            resultList
+        };
+        yield return new object[]
+        {
+            new TestEnumerable(new[]
+            {
+                new KeyValuePair<string, string>("key1", "value1"),
+                new KeyValuePair<string, string>("key2", "value2")
+            }),
+            true,
+            resultList
+        };
+        yield return new object[]
+        {
+            newtonsoftJsonObject,
+            true,
+            new List<(object, object)>()
+            {
+                new ("key1", new JValue("value1")),
+                new ("key2", new JValue("value2")),
+            }
+        };
+        yield return new object[]
+        {
+            systemTextJsonObject,
+            true,
+            new List<(object, object)>()
+            {
+                new ("key1", systemTextJsonObject.AsEnumerable().FirstOrDefault(x => x.Value!.ToString() == "value1").Value!.AsValue()),
+                new ("key2", systemTextJsonObject.AsEnumerable().FirstOrDefault(x => x.Value!.ToString() == "value2").Value!.AsValue()),
+            }
+        };
+    }
+
+    private class TestEnumerable : IEnumerable<KeyValuePair<string, string>>
+    {
+        private IEnumerable<KeyValuePair<string, string>> _internalIEnumerable;
+
+        public TestEnumerable(KeyValuePair<string, string>[] inputArray)
+        {
+            _internalIEnumerable = inputArray;
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => new TestEnumerator(_internalIEnumerable);
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private class TestEnumerator : IEnumerator<KeyValuePair<string, string>>
+        {
+            private IEnumerator<KeyValuePair<string, string>> _internalEnumerator;
+
+            public TestEnumerator(IEnumerable<KeyValuePair<string, string>> inputEnumerable)
+            {
+                _internalEnumerator = inputEnumerable.GetEnumerator();
+            }
+
+            public KeyValuePair<string, string> Current => _internalEnumerator.Current;
+
+            object IEnumerator.Current => _internalEnumerator.Current;
+
+            public void Dispose() => _internalEnumerator.Dispose();
+            public bool MoveNext() => _internalEnumerator.MoveNext();
+            public void Reset() => _internalEnumerator.Reset();
+        }
+    }
+}

--- a/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DictionaryTypeRenderer.cs
+++ b/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DictionaryTypeRenderer.cs
@@ -125,24 +125,25 @@ internal class DictionaryTypeRenderer : ICustomTypeRenderer<IRenderable>
                 if (genericArgument.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 {
                     var method = i.GetMethod("GetEnumerator", BindingFlags.Instance | BindingFlags.Public)!;
-                    var items = (IEnumerable)method.Invoke(obj, null)!;
-
+                    var getEnumeratorResult = method.Invoke(obj, null)!;
                     var list = new List<(object? key, object? value)>();
-
-                    foreach (var item in items)
+                    if (getEnumeratorResult is IEnumerator enumerator)
                     {
-                        var itemType = item.GetType();
+                        while (enumerator.MoveNext())
+                        {
+                            var item = enumerator.Current;
+                            var itemType = item.GetType();
 
-                        var keyProperty = itemType.GetProperty("Key", BindingFlags.Instance | BindingFlags.Public)!;
-                        var key = keyProperty.GetValue(item);
+                            var keyProperty = itemType.GetProperty("Key", BindingFlags.Instance | BindingFlags.Public)!;
+                            var key = keyProperty.GetValue(item);
 
-                        var valueProperty = itemType.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public)!;
-                        var value = valueProperty.GetValue(item);
+                            var valueProperty = itemType.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public)!;
+                            var value = valueProperty.GetValue(item);
 
-                        list.Add((key, value));
+                            list.Add((key, value));
+                        }
+                        return (true, list);
                     }
-
-                    return (true, list);
                 }
             }
         }


### PR DESCRIPTION
Moves over elements in the DictionaryTypeRenderer ShouldHandle usin the Enumerator instead of casting to IEnumerable solving #12

Tests for the change has been added, and all tests run.