### PR TITLE
Add caller expression argument attribute to auto label dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Dumpify
+
 [![Github version](https://badge.fury.io/nu/Dumpify.svg)](https://badge.fury.io/nu/Dumpify)
 ![example workflow](https://github.com/MoaidHathot/Dumpify/actions/workflows/build-dumpify.yml/badge.svg)
 ![Publish Nuget](https://github.com/MoaidHathot/Dumpify/actions/workflows/publish-dumpify.yml/badge.svg)
@@ -10,30 +11,34 @@ Improve productivity and debuggability by adding `.Dump()` extension methods to 
 `Dump` any object in a structured and colorful way into the Console, Trace, Debug events or your own custom output.
 
 # How to Install
+
 The library is published as a [Nuget](https://www.nuget.org/packages/Dumpify)
 
 Either run `dotnet add package Dumpify`, `Install-Package Dumpify` or use Visual Studio's [NuGet Package Manager](https://learn.microsoft.com/en-us/nuget/consume-packages/install-use-packages-visual-studio)
 
-
 # Features
+
 * Dump any object in a structured, colorful way to Console, Debug, Trace or any other custom output
 * Support Properties, Fields and non-public members
 * Support max nesting levels
 * Support circular dependencies and references
 * Support styling and customizations
 * Highly Configurable
-* Support for differnt otuput targets: Console, Trace, Debug, Text, Custom
+* Support for different output targets: Console, Trace, Debug, Text, Custom
 * Fast!
-    
-# Examples:
+
+# Examples
+
 ## Anonymous types
+
 ```csharp
 new { Name = "Dumpify", Description = "Dump any object to Console" }.Dump();
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/232251633-5830bd48-0e45-4c89-9b26-3c678230a90a.png)
 
-
 ### Support nesting and circular references
+
 ```csharp
 var moaid = new Person { FirstName = "Moaid", LastName = "Hathot", Profession = Profession.Software };
 var haneeni = new Person { FirstName = "Haneeni", LastName = "Shibli", Profession = Profession.Health };
@@ -44,17 +49,21 @@ haneeni.Spouse = moaid;
 moaid.Dump();
 //You can define max depth as well, e.g `moaid.Dump(maxDepth: 2)`
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/232280616-c6127820-7e2b-448b-81ca-1aded2894cdc.png)
 
 ### Support for Arrays, Dictionaries and Collections
+
 ```csharp
 var arr = new[] { 1, 2, 3, 4 }.Dump();
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/232251833-ef2650fe-64a3-476d-b676-4a0f73339560.png)
 
 ```csharp
 var arr2d = new int[,] { {1, 2}, {3, 4} }.Dump();
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/230250735-66703e54-ce02-41c0-91b7-fcbee5f80ac3.png)
 
 ```csharp
@@ -66,10 +75,11 @@ new Dictionary<string, string>
    ["Mikasa"] = "Ackerman",
 }.Dump();
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/232251913-add4a0d8-3355-44f6-ba94-5dfbf8d8e2ac.png)
 
-
 ### You can turn on or off fields and private members
+
 ```csharp
 public class AdditionValue
 {
@@ -88,19 +98,21 @@ public class AdditionValue
 
 new AdditionValue(1, 2).Dump(members: new MembersConfig { IncludeFields = true, IncludeNonPublicMembers = true });
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/232252840-c5b0ea4c-eae9-4dc2-bd6c-d42ee58505eb.png)
 
-
-
 ### You can customize colors
+
 ```csharp
 var package = new { Name = "Dumpify", Description = "Dump any object to Console" };
 package.Dump(colors: ColorConfig.NoColors);
 package.Dump(colors: new ColorConfig { PropertyValueColor = new DumpColor(Color.RoyalBlue)});
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/232252235-18d43c3a-0b54-475a-befc-0f957777f150.png)
 
 ### You can turn on or off type names, headers, lables and much more
+
 ```csharp
 var moaid = new Person { FirstName = "Moaid", LastName = "Hathot", Profession = Profession.Software };
 var haneeni = new Person { FirstName = "Haneeni", LastName = "Shibli", Profession = Profession.Health };
@@ -109,10 +121,11 @@ haneeni.Spouse = moaid;
 
 moaid.Dump(typeNames: new TypeNamingConfig { ShowTypeNames = false }, tableConfig: new TableConfig { ShowTableHeaders = false });
 ```
+
 ![image](https://user-images.githubusercontent.com/8770486/232252319-58a98036-5a0e-4514-8d08-df6fdff5a8a7.png)
 
-
 ### There are multiple output options (Console, Trace, Debug, Text) or provide your own
+
 ```csharp
 var package = new { Name = "Dumpify", Description = "Dump any object to Console" };
 package.Dump(); //Similar to `package.DumpConsole()` and `package.Dump(output: Outputs.Console))`
@@ -124,8 +137,8 @@ using var writer = new StringWriter();
 package.Dump(output: new DumpOutput(writer)); //Custom output
 ```
 
+### Every configuration can be defined per-Dump or globally for all Dumps, e.g
 
-### Every configuration can be defined per-Dump or globally for all Dumps, e.g:
 ```csharp
 DumpConfig.Default.TypeNamingConfig.UseAliases = true;
 DumpConfig.Default.TypeNamingConfig.ShowTypeNames = false;
@@ -134,9 +147,8 @@ DumpConfig.Default.MaxDepth = 3;
 //Much more...
 ```
 
-
-
 # Features for the future 0.7.0 release
+
 * Add configuration for formatting Anonymous Objects type names
 * Text renderer
 * Better rendering of Delegates
@@ -146,26 +158,26 @@ DumpConfig.Default.MaxDepth = 3;
 * **consider** changing the default color scheme to VsCode's
 * Documentation
 
-
 # To do
+
 * Live outputs
 * Add custom rendering for more types:
-    - Exceptions, AggregateExceptions, etc...
+  * Exceptions, AggregateExceptions, etc...
 * Rethink Generators caching keys
 * Consider using Max Depth for Descriptors
 * Refactor Renderers and make it better extendable
 * Add more renderers
-    * Text Renderers
-    * re-introduce Json
-    * CSharp Renderer
+  * Text Renderers
+  * re-introduce Json
+  * CSharp Renderer
 * Consider Decoupling from Spectre.Console
 * Tests
-    * More tests
-    * Visual (Render) Tests - consider acceptance tests
-    * Tests for Nesting
+  * More tests
+  * Visual (Render) Tests - consider acceptance tests
+  * Tests for Nesting
 * More sync between Custom Descriptors and Custom Renderers
-	* Think how we can mark type's descriptor as needing special rendering.
-	* The current CustomDescriptorGenerator must generate a value
-	* Consider ValueTuple
+  * Think how we can mark type's descriptor as needing special rendering.
+  * The current CustomDescriptorGenerator must generate a value
+  * Consider ValueTuple
 * Refactor SpectureTableRenderer to share customization code
 * Consider changing the style/view of ObjectDescriptors without properties (currently empty table)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Dumpify
-
 [![Github version](https://badge.fury.io/nu/Dumpify.svg)](https://badge.fury.io/nu/Dumpify)
 ![example workflow](https://github.com/MoaidHathot/Dumpify/actions/workflows/build-dumpify.yml/badge.svg)
 ![Publish Nuget](https://github.com/MoaidHathot/Dumpify/actions/workflows/publish-dumpify.yml/badge.svg)
@@ -11,34 +10,30 @@ Improve productivity and debuggability by adding `.Dump()` extension methods to 
 `Dump` any object in a structured and colorful way into the Console, Trace, Debug events or your own custom output.
 
 # How to Install
-
 The library is published as a [Nuget](https://www.nuget.org/packages/Dumpify)
 
 Either run `dotnet add package Dumpify`, `Install-Package Dumpify` or use Visual Studio's [NuGet Package Manager](https://learn.microsoft.com/en-us/nuget/consume-packages/install-use-packages-visual-studio)
 
-# Features
 
+# Features
 * Dump any object in a structured, colorful way to Console, Debug, Trace or any other custom output
 * Support Properties, Fields and non-public members
 * Support max nesting levels
 * Support circular dependencies and references
 * Support styling and customizations
 * Highly Configurable
-* Support for different output targets: Console, Trace, Debug, Text, Custom
+* Support for differnt otuput targets: Console, Trace, Debug, Text, Custom
 * Fast!
-
-# Examples
-
+    
+# Examples:
 ## Anonymous types
-
 ```csharp
 new { Name = "Dumpify", Description = "Dump any object to Console" }.Dump();
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/232251633-5830bd48-0e45-4c89-9b26-3c678230a90a.png)
 
-### Support nesting and circular references
 
+### Support nesting and circular references
 ```csharp
 var moaid = new Person { FirstName = "Moaid", LastName = "Hathot", Profession = Profession.Software };
 var haneeni = new Person { FirstName = "Haneeni", LastName = "Shibli", Profession = Profession.Health };
@@ -49,21 +44,17 @@ haneeni.Spouse = moaid;
 moaid.Dump();
 //You can define max depth as well, e.g `moaid.Dump(maxDepth: 2)`
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/232280616-c6127820-7e2b-448b-81ca-1aded2894cdc.png)
 
 ### Support for Arrays, Dictionaries and Collections
-
 ```csharp
 var arr = new[] { 1, 2, 3, 4 }.Dump();
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/232251833-ef2650fe-64a3-476d-b676-4a0f73339560.png)
 
 ```csharp
 var arr2d = new int[,] { {1, 2}, {3, 4} }.Dump();
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/230250735-66703e54-ce02-41c0-91b7-fcbee5f80ac3.png)
 
 ```csharp
@@ -75,11 +66,10 @@ new Dictionary<string, string>
    ["Mikasa"] = "Ackerman",
 }.Dump();
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/232251913-add4a0d8-3355-44f6-ba94-5dfbf8d8e2ac.png)
 
-### You can turn on or off fields and private members
 
+### You can turn on or off fields and private members
 ```csharp
 public class AdditionValue
 {
@@ -98,21 +88,19 @@ public class AdditionValue
 
 new AdditionValue(1, 2).Dump(members: new MembersConfig { IncludeFields = true, IncludeNonPublicMembers = true });
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/232252840-c5b0ea4c-eae9-4dc2-bd6c-d42ee58505eb.png)
 
-### You can customize colors
 
+
+### You can customize colors
 ```csharp
 var package = new { Name = "Dumpify", Description = "Dump any object to Console" };
 package.Dump(colors: ColorConfig.NoColors);
 package.Dump(colors: new ColorConfig { PropertyValueColor = new DumpColor(Color.RoyalBlue)});
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/232252235-18d43c3a-0b54-475a-befc-0f957777f150.png)
 
 ### You can turn on or off type names, headers, lables and much more
-
 ```csharp
 var moaid = new Person { FirstName = "Moaid", LastName = "Hathot", Profession = Profession.Software };
 var haneeni = new Person { FirstName = "Haneeni", LastName = "Shibli", Profession = Profession.Health };
@@ -121,11 +109,10 @@ haneeni.Spouse = moaid;
 
 moaid.Dump(typeNames: new TypeNamingConfig { ShowTypeNames = false }, tableConfig: new TableConfig { ShowTableHeaders = false });
 ```
-
 ![image](https://user-images.githubusercontent.com/8770486/232252319-58a98036-5a0e-4514-8d08-df6fdff5a8a7.png)
 
-### There are multiple output options (Console, Trace, Debug, Text) or provide your own
 
+### There are multiple output options (Console, Trace, Debug, Text) or provide your own
 ```csharp
 var package = new { Name = "Dumpify", Description = "Dump any object to Console" };
 package.Dump(); //Similar to `package.DumpConsole()` and `package.Dump(output: Outputs.Console))`
@@ -137,8 +124,8 @@ using var writer = new StringWriter();
 package.Dump(output: new DumpOutput(writer)); //Custom output
 ```
 
-### Every configuration can be defined per-Dump or globally for all Dumps, e.g
 
+### Every configuration can be defined per-Dump or globally for all Dumps, e.g:
 ```csharp
 DumpConfig.Default.TypeNamingConfig.UseAliases = true;
 DumpConfig.Default.TypeNamingConfig.ShowTypeNames = false;
@@ -147,8 +134,9 @@ DumpConfig.Default.MaxDepth = 3;
 //Much more...
 ```
 
-# Features for the future 0.7.0 release
 
+
+# Features for the future 0.7.0 release
 * Add configuration for formatting Anonymous Objects type names
 * Text renderer
 * Better rendering of Delegates
@@ -158,26 +146,26 @@ DumpConfig.Default.MaxDepth = 3;
 * **consider** changing the default color scheme to VsCode's
 * Documentation
 
-# To do
 
+# To do
 * Live outputs
 * Add custom rendering for more types:
-  * Exceptions, AggregateExceptions, etc...
+    - Exceptions, AggregateExceptions, etc...
 * Rethink Generators caching keys
 * Consider using Max Depth for Descriptors
 * Refactor Renderers and make it better extendable
 * Add more renderers
-  * Text Renderers
-  * re-introduce Json
-  * CSharp Renderer
+    * Text Renderers
+    * re-introduce Json
+    * CSharp Renderer
 * Consider Decoupling from Spectre.Console
 * Tests
-  * More tests
-  * Visual (Render) Tests - consider acceptance tests
-  * Tests for Nesting
+    * More tests
+    * Visual (Render) Tests - consider acceptance tests
+    * Tests for Nesting
 * More sync between Custom Descriptors and Custom Renderers
-  * Think how we can mark type's descriptor as needing special rendering.
-  * The current CustomDescriptorGenerator must generate a value
-  * Consider ValueTuple
+	* Think how we can mark type's descriptor as needing special rendering.
+	* The current CustomDescriptorGenerator must generate a value
+	* Consider ValueTuple
 * Refactor SpectureTableRenderer to share customization code
 * Consider changing the style/view of ObjectDescriptors without properties (currently empty table)

--- a/src/Dumpify/Extensions/DumpExtensions.cs
+++ b/src/Dumpify/Extensions/DumpExtensions.cs
@@ -3,30 +3,32 @@ using Dumpify.Descriptors;
 using Dumpify.Descriptors.ValueProviders;
 using Dumpify.Extensions;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
 
 namespace Dumpify;
 
 public static class DumpExtensions
 {
     [return: NotNullIfNotNull(nameof(obj))]
-    public static T? DumpDebug<T>(this T? obj, string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
+    public static T? DumpDebug<T>(this T? obj, [CallerArgumentExpression(nameof(obj))] string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
     {
         outputConfig ??= new OutputConfig { WidthOverride = 250 };
         return obj.Dump(label: label, maxDepth: maxDepth, renderer: renderer, useDescriptors: useDescriptors, typeNames: typeNames, colors: colors, output: Dumpify.Outputs.Debug, members: members, tableConfig: tableConfig, outputConfig: outputConfig);
     }
 
     [return: NotNullIfNotNull(nameof(obj))]
-    public static T? DumpTrace<T>(this T? obj, string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
+    public static T? DumpTrace<T>(this T? obj, [CallerArgumentExpression(nameof(obj))] string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
     {
         outputConfig ??= new OutputConfig { WidthOverride = 250 };
         return obj.Dump(label: label, maxDepth: maxDepth, renderer: renderer, useDescriptors: useDescriptors, typeNames: typeNames, colors: colors, output: Dumpify.Outputs.Trace, members: members, tableConfig: tableConfig, outputConfig: outputConfig);
     }
 
     [return: NotNullIfNotNull(nameof(obj))]
-    public static T? DumpConsole<T>(this T? obj, string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
+    public static T? DumpConsole<T>(this T? obj, [CallerArgumentExpression(nameof(obj))] string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
         => obj.Dump(label: label, maxDepth: maxDepth, renderer: renderer, useDescriptors: useDescriptors, typeNames: typeNames, colors: colors, output: Dumpify.Outputs.Console, members: members, tableConfig: tableConfig, outputConfig: outputConfig);
 
-    public static string DumpText<T>(this T? obj, string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
+    public static string DumpText<T>(this T? obj, [CallerArgumentExpression(nameof(obj))] string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
     {
         using var writer = new StringWriter();
 
@@ -39,7 +41,7 @@ public static class DumpExtensions
     }
 
     [return: NotNullIfNotNull(nameof(obj))]
-    public static T? Dump<T>(this T? obj, string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, IDumpOutput? output = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
+    public static T? Dump<T>(this T? obj, [CallerArgumentExpression(nameof(obj))] string? label = null, int? maxDepth = null, IRenderer? renderer = null, bool? useDescriptors = null, ColorConfig? colors = null, IDumpOutput? output = null, MembersConfig? members = null, TypeNamingConfig? typeNames = null, TableConfig? tableConfig = null, OutputConfig? outputConfig = null)
     {
         var defaultConfig = DumpConfig.Default;
 

--- a/src/Dumpify/Polyfills/CallerArgumentExresspion.cs
+++ b/src/Dumpify/Polyfills/CallerArgumentExresspion.cs
@@ -1,0 +1,20 @@
+#if NETFRAMEWORK || NETSTANDARD || NETCOREAPP2X
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.CompilerServices;
+
+[ExcludeFromCodeCoverage]
+[DebuggerNonUserCode]
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class CallerArgumentExpressionAttribute :
+    Attribute
+{
+    public CallerArgumentExpressionAttribute(string parameterName) =>
+        ParameterName = parameterName;
+
+    public string ParameterName { get; }
+}
+
+#endif


### PR DESCRIPTION
Hi - great library! I've been using this and I thought it'd be useful to use the [caller argument expression](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/caller-argument-expression) attribute to set the label to the variable name that is being dumped when not otherwise provided. 

Just thought it'd be useful 
