### PR TITLE
Implement IncludeVirtualMembers in MembersConfig

### DIFF
--- a/src/Dumpify.Tests/Providers/MemberProviderTests.cs
+++ b/src/Dumpify.Tests/Providers/MemberProviderTests.cs
@@ -1,0 +1,24 @@
+namespace Dumpify.Tests.Providers;
+
+public class MemberProviderTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IncludeVirtualMembers(bool includeVirtualMembers)
+    {
+        var membersConfig = new MembersConfig { IncludeVirtualMembers = includeVirtualMembers };
+        var testClass = new ClassWithVirtualProperty();
+
+        var output = testClass.DumpText(members: membersConfig);
+        var isContainsVirtualProperty = output.Contains(testClass.Bar);
+
+        includeVirtualMembers.Should().Be(isContainsVirtualProperty);
+    }
+
+    private class ClassWithVirtualProperty
+    {
+        public string Foo { get; set; } = "Oleg";
+        public virtual string Bar { get; set; } = "Hello";
+    }
+}

--- a/src/Dumpify/Config/MembersConfig.cs
+++ b/src/Dumpify/Config/MembersConfig.cs
@@ -4,6 +4,7 @@ public class MembersConfig
 {
     public bool IncludePublicMembers { get; set; } = true;
     public bool IncludeNonPublicMembers { get; set; } = false;
+    public bool IncludeVirtualMembers { get; set; } = true;
     public bool IncludeProperties { get; set; } = true;
     public bool IncludeFields { get; set; } = false;
 }

--- a/src/Dumpify/Extensions/DumpExtensions.cs
+++ b/src/Dumpify/Extensions/DumpExtensions.cs
@@ -179,7 +179,8 @@ public static class DumpExtensions
                 membersConfig.IncludeProperties,
                 membersConfig.IncludeFields,
                 membersConfig.IncludePublicMembers,
-                membersConfig.IncludeNonPublicMembers
+                membersConfig.IncludeNonPublicMembers,
+                membersConfig.IncludeVirtualMembers
             ),
             TypeNameProvider = new TypeNameProvider(
                 typeNamingConfig.UseAliases,


### PR DESCRIPTION
Resolves https://github.com/MoaidHathot/Dumpify/issues/20 (Virtual Member)

Implemented the ability to include/exclude virtual members in MembersConfig.

**By default, virtual members will be displayed.**

Tested both in the global configuration via  `DumpConfig.Default.MembersConfig.IncludeVirtualMembers` and by passing the config directly to the `Dump()` method.

I've also written xUnit tests to check the inclusion of virtual members, hopefully they will be useful.