### PR TITLE
Added member filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ new AdditionValue(1, 2).Dump(members: new MembersConfig { IncludeFields = true, 
 ```
 ![image](https://user-images.githubusercontent.com/8770486/232252840-c5b0ea4c-eae9-4dc2-bd6c-d42ee58505eb.png)
 
+### You can provide a custom filter to determine if members should be included or not
+```csharp
+public class Person
+{
+    public string Name { get; set; }
+
+    [JsonIgnore]
+    public string SensitiveData { get; set; }
+}
+
+new Person()
+{
+    Name = "Moaid",
+    SensitiveData = "We don't want this to show up"
+}.Dump(members: new MembersConfig { MemberFilter = member => !member.Info.CustomAttributes.Any(a => a.AttributeType == typeof(JsonIgnoreAttribute)) });
+```
+
 ### You can turn on or off row separators and a type column
 ```csharp
 //globally

--- a/src/Dumpify.Tests/Providers/MemberProviderTests.cs
+++ b/src/Dumpify.Tests/Providers/MemberProviderTests.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using Xunit.Abstractions;
+
 namespace Dumpify.Tests.Providers;
 
 public class MemberProviderTests
@@ -16,9 +19,49 @@ public class MemberProviderTests
         includeVirtualMembers.Should().Be(isContainsVirtualProperty);
     }
 
+    [Theory]
+    [ClassData(typeof(MemberFilterData))]
+    public void ApplyMemberFilter(Func<IValueProvider, bool>? filter, bool mustIncludeFoo)
+    {
+        var membersConfig = new MembersConfig { MemberFilter = filter };
+        var testClass = new ClassWithFilterableProperty();
+
+        var output = testClass.DumpText(members: membersConfig);
+        var isContainsFoo = output.Contains(testClass.Foo);
+
+        isContainsFoo.Should().Be(mustIncludeFoo);
+    }
+
     private class ClassWithVirtualProperty
     {
         public string Foo { get; set; } = "Oleg";
         public virtual string Bar { get; set; } = "Hello";
+    }
+
+    private class ClassWithFilterableProperty
+    {
+        [JsonIgnore]
+        public string Foo { get; set; } = "Oleg";
+        public virtual string Bar { get; set; } = "Hello";
+    }
+
+    private class MemberFilterData : IEnumerable<object?[]>
+    {
+        public IEnumerator<object?[]> GetEnumerator()
+        {
+            // Properties that don't have the Foo name will be included
+            yield return new object?[] { new Func<IValueProvider, bool>(member => member.Info.Name != nameof(ClassWithFilterableProperty.Foo)), false };
+            
+            // Only properties that have the Foo name will be included
+            yield return new object?[] { new Func<IValueProvider, bool>(member => member.Info.Name == nameof(ClassWithFilterableProperty.Foo)), true };
+            
+            // If the JsonIgnore attribute is applied, don't include the property
+            yield return new object?[] { new Func<IValueProvider, bool>(member => !member.Info.CustomAttributes.Any(a => a.AttributeType == typeof(JsonIgnoreAttribute))), false };
+            
+            // If there is no filter provided, filtering will not be applied
+            yield return new object?[] { null, true };
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Dumpify/Config/MembersConfig.cs
+++ b/src/Dumpify/Config/MembersConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Dumpify;
+﻿using Dumpify.Descriptors.ValueProviders;
+
+namespace Dumpify;
 
 public class MembersConfig
 {
@@ -7,4 +9,5 @@ public class MembersConfig
     public bool IncludeVirtualMembers { get; set; } = true;
     public bool IncludeProperties { get; set; } = true;
     public bool IncludeFields { get; set; } = false;
+    public Func<IValueProvider, bool>? MemberFilter { get; set; }
 }

--- a/src/Dumpify/Extensions/DumpExtensions.cs
+++ b/src/Dumpify/Extensions/DumpExtensions.cs
@@ -180,7 +180,8 @@ public static class DumpExtensions
                 membersConfig.IncludeFields,
                 membersConfig.IncludePublicMembers,
                 membersConfig.IncludeNonPublicMembers,
-                membersConfig.IncludeVirtualMembers
+                membersConfig.IncludeVirtualMembers,
+                membersConfig.MemberFilter
             ),
             TypeNameProvider = new TypeNameProvider(
                 typeNamingConfig.UseAliases,


### PR DESCRIPTION
Allows providing a custom function that determines if a member should be included or not.

As mentioned in the readme:

### You can provide a custom filter to determine if members should be included or not

```csharp
public class Person
{
    public string Name { get; set; }

    [JsonIgnore]
    public string SensitiveData { get; set; }
}

new Person()
{
    Name = "Moaid",
    SensitiveData = "We don't want this to show up"
}.Dump(members: new MembersConfig { MemberFilter = member => !member.Info.CustomAttributes.Any(a => a.AttributeType == typeof(JsonIgnoreAttribute)) });
```