### PR TITLE
Add an option to limit how many elements to render for collections and arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ new Dictionary<string, string>
 ```
 ![image](https://user-images.githubusercontent.com/8770486/232251913-add4a0d8-3355-44f6-ba94-5dfbf8d8e2ac.png)
 
+You can ensure that arrays, dictionaries and collections don't output too much by allowing results to be truncated. Do this by setting the `MaxCollectionCount` property in the tableConfig.
+
+```csharp
+int[] arr = [1, 2, 3, 4];
+
+// Outputs only the first two elements and a message that says: ... truncated 2 items
+arr.Dump(tableConfig: new () { MaxCollectionCount = 2 });
+```
 
 ### You can turn on or off fields and private members
 ```csharp

--- a/src/Dumpify.Playground/Program.cs
+++ b/src/Dumpify.Playground/Program.cs
@@ -4,6 +4,9 @@ using System.Collections;
 using System.Data;
 using System.Text;
 
+int[] arr = [1, 2, 3, 4];
+arr.Dump(tableConfig: new () { MaxCollectionCount = 2 });
+
 //DumpConfig.Default.Renderer = Renderers.Text;
 //DumpConfig.Default.ColorConfig = ColorConfig.NoColors;
 

--- a/src/Dumpify.Tests/Renderers/Spectre.Console/MultiValueTruncationTests.cs
+++ b/src/Dumpify.Tests/Renderers/Spectre.Console/MultiValueTruncationTests.cs
@@ -1,0 +1,225 @@
+﻿using System.Collections;
+using System.Data;
+using Xunit.Abstractions;
+
+namespace Dumpify.Tests.Renderers.Spectre.Console;
+public class MultiValueTruncationTests
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public MultiValueTruncationTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Theory]
+    [ClassData(typeof(TruncateCollectionsData))]
+    public void TruncateCollections(string name, object collection, int maxCount, string[] shouldContainItems, string[] shouldNotContainItems)
+    {
+        //Arrange
+        _testOutputHelper.WriteLine($"Test: {name}");
+
+        //Act
+        var result = collection.DumpText(tableConfig: new TableConfig() { MaxCollectionCount = maxCount });
+
+        _testOutputHelper.WriteLine(result);
+
+        //Assert
+        foreach(var shouldContain in shouldContainItems)
+        {
+            result.Should().Contain(shouldContain);
+        }
+
+        foreach (var shouldNotContain in shouldNotContainItems)
+        {
+            result.Should().NotContain(shouldNotContain);
+        }
+    }
+
+    public class TruncateCollectionsData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[]
+            {
+                "Don't truncate if the number of items is equal to the max count",
+                Enumerable.Range(1, 10).ToArray(),
+                10,
+                new [] { "9 │ 10" },
+                new [] { "... truncated" }
+            };
+
+            yield return new object[]
+            {
+                "Don't truncate if the number of items is smaller than the max count",
+                Enumerable.Range(1, 10).ToArray(),
+                20,
+                new [] { "9 │ 10" },
+                new [] { " ... truncated" }
+            };
+
+            yield return new object[]
+            {
+                "Truncate if the number of items is greater than the max count",
+                Enumerable.Range(1, 10).ToArray(),
+                5,
+                new [] { "4 │ 5", "  │ ... truncated 5 items" },
+                new [] { "5 │ 6" }
+            };
+
+            yield return new object[]
+            {
+                "Truncate for lists",
+                Enumerable.Range(1, 10).ToList(),
+                5,
+                new [] { "│ 5", "│ ... truncated 5 items" },
+                new [] { "│ 6" }
+            };
+
+            yield return new object[]
+            {
+                "Truncate for data tables",
+                CreateDataTable(10),
+                5,
+                new []
+                    {
+                        "│ 4      │ 8      │ 12     │ 16     │ 20     │        │",
+                        "│ Value1 │ Value2 │ Value3 │ Value4 │ Value5 │ ... +5 │",
+                        "│ ... +5 │        │        │"
+                    },
+                new [] { "│ 5      │ 10    │ 15     │ 20     │ 25     │        │" }
+            };
+
+            yield return new object[]
+            {
+                "Truncate for datasets",
+                CreateDataSet(4),
+                2,
+                new [] { "Table 2", "... truncated 2 more tables" },
+                new [] { "Table 3" }
+            };
+
+            yield return new object[]
+            {
+                "Truncate for dictionaries",
+                Enumerable.Range(1, 10).ToDictionary(x => x, x => $"value for {x}"),
+                5,
+                new []
+                    {
+                        "│ 5   │ \"value for 5\"",
+                        "│     │ ... truncated 5 items │"
+                    },
+                new [] { "│ 6   │ \"value for 6\"" }
+            };
+
+            yield return new object[]
+            {
+                "Truncate for two-dimensional arrays",
+                new int[6, 6]
+                {
+                    { 1, 2, 3, 4, 5, 6 },
+                    { 1, 2, 3, 4, 5, 6 },
+                    { 1, 2, 3, 4, 5, 6 },
+                    { 1, 2, 3, 4, 5, 6 },
+                    { 1, 2, 3, 4, 5, 6 },
+                    { 1, 2, 3, 4, 5, 6 }
+                },
+                3,
+                new []
+                    {
+                        "│ 2      │ 1 │ 2 │ 3 │        │",
+                        "│ #      │ 0 │ 1 │ 2 │ ... +3 │",
+                        "│ ... +3 │   │   │   │        │"
+                    },
+                new []
+                    {
+                        "│ 3      │ 1 │ 2 │ 3 │        │"
+                    }
+            };
+
+            yield return new object[]
+            {
+                "Truncate for three-dimensional arrays (they get flattened to a single list)",
+                new int[4, 4, 4]
+                {
+                    {
+                        { 1, 2, 3, 4 },
+                        { 5, 6, 7, 8 },
+                        { 9, 10, 11, 12 },
+                        { 13, 14, 15, 16 }
+                    },
+                    {
+                        { 17, 18, 19, 20 },
+                        { 21, 22, 23, 24 },
+                        { 25, 26, 27, 28 },
+                        { 29, 30, 31, 32 }
+                    },
+                    {
+                        { 33, 34, 35, 36 },
+                        { 37, 38, 39, 40 },
+                        { 41, 42, 43, 44 },
+                        { 45, 46, 47, 48 }
+                    },
+                    {
+                        { 49, 50, 51, 52 },
+                        { 53, 54, 55, 56 },
+                        { 57, 58, 59, 60 },
+                        { 61, 62, 63, 64 }
+                    }
+                },
+                10,
+                new []
+                    {
+                        "│ 10",
+                        "│ ... truncated 54 items"
+                    },
+                new []
+                    {
+                        "│ 11"
+                    }
+            };
+        }
+
+        private static DataSet CreateDataSet(int tables)
+        {
+            DataSet dataSet = new DataSet();
+            for (int i = 0; i < tables; i++)
+            {
+                var dataTable = CreateDataTable(10);
+                dataTable.TableName = $"Table {i + 1}";
+                dataSet.Tables.Add(dataTable);
+            }
+
+            return dataSet;
+        }
+
+        private static DataTable CreateDataTable(int rows)
+        {
+            var dataTable = new DataTable
+            {
+                Columns =
+                    {
+                        new DataColumn("Value1", typeof(int)),
+                        new DataColumn("Value2", typeof(int)),
+                        new DataColumn("Value3", typeof(int)),
+                        new DataColumn("Value4", typeof(int)),
+                        new DataColumn("Value5", typeof(int)),
+                        new DataColumn("Value6", typeof(int)),
+                        new DataColumn("Value7", typeof(int)),
+                        new DataColumn("Value8", typeof(int)),
+                        new DataColumn("Value9", typeof(int)),
+                        new DataColumn("Value10", typeof(int))
+                    }
+            };
+
+            for(int i = 0; i < rows; i++)
+            {
+                dataTable.Rows.Add(i * 1, i * 2, i * 3, i * 4, i * 5, i * 6, i * 7, i * 8, i * 9, i * 10);
+            }
+
+            return dataTable;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Dumpify/Config/TableConfig.cs
+++ b/src/Dumpify/Config/TableConfig.cs
@@ -8,4 +8,5 @@ public class TableConfig
     public bool ExpandTables { get; set; } = false;
     public bool ShowMemberTypes { get; set; } = false;
     public bool ShowRowSeparators { get; set; } = false;
+    public int MaxCollectionCount { get; set; } = int.MaxValue;
 }

--- a/src/Dumpify/Descriptors/LabelDescriptor.cs
+++ b/src/Dumpify/Descriptors/LabelDescriptor.cs
@@ -1,0 +1,7 @@
+﻿using Dumpify.Descriptors.ValueProviders;
+
+namespace Dumpify.Descriptors;
+internal record LabelDescriptor(Type Type, IValueProvider? ValueProvider) : IDescriptor
+{
+    public string Name => ValueProvider?.Name ?? Type.Name;
+}

--- a/src/Dumpify/Renderers/RendererBase.cs
+++ b/src/Dumpify/Renderers/RendererBase.cs
@@ -60,6 +60,7 @@ internal abstract class RendererBase<TRenderable, TState> : IRenderer, IRenderer
             SingleValueDescriptor singleDescriptor => TryRenderCustomTypeDescriptor(@object, singleDescriptor, context, RenderSingleValueDescriptor),
             ObjectDescriptor objDescriptor => TryRenderCustomTypeDescriptor(@object, objDescriptor, context, TryRenderObjectDescriptor),
             MultiValueDescriptor multiDescriptor => TryRenderCustomTypeDescriptor(@object, multiDescriptor, context, RenderMultiValueDescriptor),
+            LabelDescriptor labelDescriptor => TryRenderCustomTypeDescriptor(@object, labelDescriptor, context, RenderLabelDescriptor),
             CustomDescriptor customDescriptor => TryRenderCustomTypeDescriptor(@object, customDescriptor, context, RenderCustomDescriptor),
             _ => RenderUnsupportedDescriptor(@object, descriptor, context),
         };
@@ -170,6 +171,6 @@ internal abstract class RendererBase<TRenderable, TState> : IRenderer, IRenderer
     protected abstract TRenderable RenderUnsupportedDescriptor(object obj, IDescriptor descriptor, RenderContext<TState> context);
     protected abstract TRenderable RenderObjectDescriptor(object obj, ObjectDescriptor descriptor, RenderContext<TState> context);
     protected abstract TRenderable RenderMultiValueDescriptor(object obj, MultiValueDescriptor descriptor, RenderContext<TState> context);
-
+    protected abstract TRenderable RenderLabelDescriptor(object obj, LabelDescriptor descriptor, RenderContext<TState> context);
     protected abstract TState CreateState(object? obj, IDescriptor? descriptor, RendererConfig config);
 }

--- a/src/Dumpify/Renderers/Spectre.Console/Builder/RowIndicesTableBuilderBehavior.cs
+++ b/src/Dumpify/Renderers/Spectre.Console/Builder/RowIndicesTableBuilderBehavior.cs
@@ -7,6 +7,7 @@ namespace Dumpify;
 public class RowIndicesTableBuilderBehavior : ITableBuilderBehavior
 {
     private readonly string _indexColumnName = Markup.Escape("#");
+    private readonly Dictionary<int, string?> _rowIndexOverrides = new();
 
     public IEnumerable<IRenderable> GetAdditionalCells(object? obj, IDescriptor? currentDescriptor, RenderContext<SpectreRendererState> context)
     {
@@ -21,7 +22,17 @@ public class RowIndicesTableBuilderBehavior : ITableBuilderBehavior
     public IEnumerable<IRenderable> GetAdditionalRowElements(BehaviorContext behaviorContext, RenderContext<SpectreRendererState> context)
     {
         var index = behaviorContext.AddedRows;
+        if(_rowIndexOverrides.ContainsKey(index))
+        {
+            yield return new Markup(Markup.Escape(_rowIndexOverrides[index] ?? string.Empty), new Style(foreground: context.State.Colors.ColumnNameColor));
+            yield break;
+        }
 
         yield return new Markup(Markup.Escape(index.ToString()), new Style(foreground: context.State.Colors.ColumnNameColor));
+    }
+
+    public void AddHideIndexForRow(int row, string? value = null)
+    {
+        _rowIndexOverrides.Add(row, value);
     }
 }

--- a/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DataSetTypeRenderer.cs
+++ b/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DataSetTypeRenderer.cs
@@ -33,12 +33,21 @@ internal class DataSetTypeRenderer : ICustomTypeRenderer<IRenderable>
 
         tableBuilder.AddColumnName(title, new Style(foreground: context.State.Colors.TypeNameColor));
 
-        foreach (DataTable dataTable in dataSet.Tables)
+        int maxCollectionCount = context.Config.TableConfig.MaxCollectionCount;
+        int length = dataSet.Tables.Count > maxCollectionCount ? maxCollectionCount : dataSet.Tables.Count;
+
+        for(int i = 0; i < length; i++)
         {
+            var dataTable = dataSet.Tables[i];
             var tableDescriptor = DumpConfig.Default.Generator.Generate(typeof(DataTable), null, context.Config.MemberProvider);
             var renderedItem = _handler.RenderDescriptor(dataTable, tableDescriptor, context);
 
             tableBuilder.AddRow(tableDescriptor, dataTable, renderedItem);
+        }
+
+        if(dataSet.Tables.Count > maxCollectionCount)
+        {
+            tableBuilder.AddRow(null, null, new Markup($"... truncated {dataSet.Tables.Count - maxCollectionCount} more tables"));
         }
 
         return tableBuilder.Build();

--- a/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DataTableTypeRenderer.cs
+++ b/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/DataTableTypeRenderer.cs
@@ -2,6 +2,7 @@
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using System.Data;
+using System.Data.Common;
 
 namespace Dumpify;
 
@@ -32,28 +33,80 @@ internal class DataTableTypeRenderer : ICustomTypeRenderer<IRenderable>
 
         builder.SetTitle(title);
 
-        foreach (DataColumn column in dataTable.Columns)
+        int maxCollectionCount = context.Config.TableConfig.MaxCollectionCount;
+        int rows = dataTable.Rows.Count > maxCollectionCount ? maxCollectionCount : dataTable.Rows.Count;
+        int columns = dataTable.Columns.Count > maxCollectionCount ? maxCollectionCount : dataTable.Columns.Count;
+
+        var dataTableContents = new object[rows, columns];
+
+        for(int column = 0; column < columns; column++)
         {
-            builder.AddColumnName(column.ColumnName);
+            for(int row = 0; row < rows; row++)
+            {
+                dataTableContents[row, column] = dataTable.Rows[row][column];
+            }
         }
 
-        foreach (DataRow row in dataTable.Rows)
+        for (int column = 0; column < columns; column++)
         {
-            var renderables = row.ItemArray.Select(item => RenderTableCell(item, context)).ToArray();
-            builder.AddRow(null, row, renderables);
+            builder.AddColumnName(dataTable.Columns[column].ColumnName);
+        }
+
+        if (dataTable.Columns.Count > maxCollectionCount)
+        {
+            builder.AddColumnName($"... +{dataTable.Columns.Count - maxCollectionCount}");
+        }
+
+        for (int row = 0; row < rows; row++)
+        {
+            List<object?> rowContents = new();
+            List<IRenderable> renderables = new();
+            for (int column = 0; column < columns; column++)
+            {
+                rowContents.Add(dataTableContents[row, column]);
+                renderables.Add(RenderTableCell(dataTableContents[row, column], context));
+            }
+
+            if (dataTable.Columns.Count > maxCollectionCount)
+            {
+                rowContents.Add(string.Empty);
+                renderables.Add(RenderTableCell(string.Empty, context, true));
+            }
+
+            builder.AddRow(null, rowContents, renderables);
+        }
+
+        if (dataTable.Rows.Count > maxCollectionCount)
+        {
+            var rowCells = new List<IRenderable>();
+            for (int i = 0; i <= columns; i++)
+            {
+                var truncatedNotificationText = $"... +{dataTable.Rows.Count - maxCollectionCount}";
+                if (i > 0)
+                {
+                    truncatedNotificationText = string.Empty;
+                }
+
+                var renderedCell = RenderTableCell(truncatedNotificationText, context, true);
+                rowCells.Add(renderedCell);
+            }
+
+            builder.AddRow(null, null, rowCells);
         }
 
         return builder.Build();
     }
 
-    private IRenderable RenderTableCell(object? obj, RenderContext<SpectreRendererState> context)
+    private IRenderable RenderTableCell(object? obj, RenderContext<SpectreRendererState> context, bool asLabel = false)
     {
         if (obj is null)
         {
             return _handler.RenderNullValue(null, context);
         }
 
-        var descriptor = DumpConfig.Default.Generator.Generate(obj.GetType(), null, context.Config.MemberProvider);
+        var descriptor = asLabel
+            ? new LabelDescriptor(obj.GetType(), null)
+            : DumpConfig.Default.Generator.Generate(obj.GetType(), null, context.Config.MemberProvider);
         var rendered = _handler.RenderDescriptor(obj, descriptor, context);
 
         return rendered;

--- a/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/LabelRenderer.cs
+++ b/src/Dumpify/Renderers/Spectre.Console/TableRenderer/CustomTypeRenderers/LabelRenderer.cs
@@ -1,0 +1,29 @@
+﻿using Dumpify.Descriptors;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Dumpify;
+internal class LabelRenderer : ICustomTypeRenderer<IRenderable>
+{
+    public Type DescriptorType => typeof(LabelDescriptor);
+
+    private readonly IRendererHandler<IRenderable, SpectreRendererState> _handler;
+
+    public LabelRenderer(IRendererHandler<IRenderable, SpectreRendererState> handler)
+    {
+        _handler = handler;
+    }
+
+    public IRenderable Render(IDescriptor descriptor, object obj, RenderContext baseContext, object? handleContext)
+    {
+        var context = (RenderContext<SpectreRendererState>)baseContext;
+
+        var propertyValueColor = context.Config.ColorConfig.PropertyValueColor?.HexString ?? "default";
+        
+        var markup = new Markup($"[{propertyValueColor}]{obj}[/]");
+        return markup;
+    }
+
+    public (bool shouldHandle, object? handleContext) ShouldHandle(IDescriptor descriptor, object obj)
+        => (descriptor.Type == typeof(string), null);
+}

--- a/src/Dumpify/Renderers/Spectre.Console/TableRenderer/SpectreConsoleTableRenderer.cs
+++ b/src/Dumpify/Renderers/Spectre.Console/TableRenderer/SpectreConsoleTableRenderer.cs
@@ -4,6 +4,7 @@ using Spectre.Console;
 using Spectre.Console.Rendering;
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Drawing;
 
 namespace Dumpify;
 
@@ -21,10 +22,14 @@ internal class SpectreConsoleTableRenderer : SpectreConsoleRendererBase
         AddCustomTypeDescriptor(new SystemReflectionTypeRenderer(this));
         AddCustomTypeDescriptor(new TimeTypesRenderer(this));
         AddCustomTypeDescriptor(new GuidTypeRenderer(this));
+        AddCustomTypeDescriptor(new LabelRenderer(this));
     }
 
     protected override IRenderable RenderMultiValueDescriptor(object obj, MultiValueDescriptor descriptor, RenderContext<SpectreRendererState> context)
         => RenderIEnumerable((IEnumerable)obj, descriptor, context);
+
+    protected override IRenderable RenderLabelDescriptor(object obj, LabelDescriptor descriptor, RenderContext<SpectreRendererState> context)
+        => new Markup(Markup.Escape(obj.ToString() ?? ""));
 
     private IRenderable RenderIEnumerable(IEnumerable obj, MultiValueDescriptor descriptor, RenderContext<SpectreRendererState> context)
     {
@@ -35,14 +40,33 @@ internal class SpectreConsoleTableRenderer : SpectreConsoleRendererBase
 
         builder.AddColumnName(typeName + "", new Style(foreground: context.State.Colors.TypeNameColor));
 
+        var items = new ArrayList();
         foreach (var item in obj)
         {
+            items.Add(item);
+        }
+
+        int maxCollectionCount = context.Config.TableConfig.MaxCollectionCount;
+        int length = items.Count > maxCollectionCount ? maxCollectionCount : items.Count;
+
+        for(int i = 0; i < length; i++)
+        {
+            var item = items[i];
             var type = descriptor.ElementsType ?? item?.GetType();
 
             IDescriptor? itemsDescriptor = type is not null ? DumpConfig.Default.Generator.Generate(type, null, context.Config.MemberProvider) : null;
 
             var renderedItem = RenderDescriptor(item, itemsDescriptor, context);
             builder.AddRow(itemsDescriptor, item, renderedItem);
+        }
+
+        if (items.Count > maxCollectionCount)
+        {
+            string truncatedNotificationText = $"... truncated {items.Count - maxCollectionCount} items";
+
+            var labelDescriptor = new LabelDescriptor(typeof(string), null);
+            var renderedItem = RenderDescriptor(truncatedNotificationText, labelDescriptor, context);
+            builder.AddRow(labelDescriptor, truncatedNotificationText, renderedItem);
         }
 
         return builder.Build();

--- a/src/Dumpify/Renderers/Spectre.Console/TextRenderer/SpectreConsoleTextRenderer.cs
+++ b/src/Dumpify/Renderers/Spectre.Console/TextRenderer/SpectreConsoleTextRenderer.cs
@@ -36,6 +36,9 @@ internal class SpectreConsoleTextRenderer : SpectreConsoleRendererBase
     protected override IRenderable RenderSingleValue(object value, RenderContext<SpectreRendererState> context, Color? color)
         => new TextRenderableAdapter(value.ToString() ?? "", new Style(foreground: color));
 
+    protected override IRenderable RenderLabelDescriptor(object obj, LabelDescriptor descriptor, RenderContext<SpectreRendererState> context)
+        => new Markup(Markup.Escape(obj.ToString() ?? ""));
+
     protected override IRenderable RenderMultiValueDescriptor(object obj, MultiValueDescriptor descriptor, RenderContext<SpectreRendererState> context)
     {
         var items = (IEnumerable)obj;


### PR DESCRIPTION
As mentioned in the readme:

You can ensure that arrays, dictionaries and collections don't output too much by allowing results to be truncated. Do this by setting the `MaxCollectionCount` property in the tableConfig.

```csharp
int[] arr = [1, 2, 3, 4];

// Outputs only the first two elements and a message that says: ... truncated 2 items
arr.Dump(tableConfig: new () { MaxCollectionCount = 2 });
```